### PR TITLE
Semantic version en tags de release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 after_success:
-- mvn deploy
+- test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && mvn deploy
 before_install:
 - openssl aes-256-cbc -K $encrypted_82a7a4aaf212_key -iv $encrypted_82a7a4aaf212_iv
   -in settings.xml.enc -out settings.xml -d

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
 					<useReleaseProfile>false</useReleaseProfile>
 					<releaseProfiles>release</releaseProfiles>
 					<goals>deploy</goals>
+					<tagNameFormat>v@{project.version}</tagNameFormat>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
El cambio este cambia el nombre default del tag que se crea al hacer `mvn --batch-mode release:prepare` a, por ejemplo, v3.5.1. 

Si bien puede parecer una boludez no lo es, porque mi próximo paso es configurar Travis para que cada vez que encuentre un tag con ese formato haga un release a Sonatype, de esa forma nos ahorramos la configuración local de cada developer. Para evitar que el developer ponga un nombre de tag distinto es que cambio este default.

@flbulgarelli necesito tu opinión en esto, si estás de acuerdo le damos para adelante.
